### PR TITLE
Fix --only flag: respect all post types

### DIFF
--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -223,7 +223,8 @@ class MigrationAgent {
 			$post_in = array_map( 'intval', $post_in );
 			$post_in = array_filter( $post_in );
 
-			$query_params['post__in'] = $post_in;
+			$query_params['post__in']  = $post_in;
+			$query_params['post_type'] = 'any';
 		}
 
 		$query = new \WP_Query( $query_params );

--- a/tests/ConvertToBlocks/MigrationAgentTest.php
+++ b/tests/ConvertToBlocks/MigrationAgentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ConvertToBlocks;
+
+class MigrationAgentTest extends \WP_UnitTestCase {
+
+	public $agent;
+
+	function setUp(): void {
+		parent::setUp();
+		$this->agent = new MigrationAgent();
+	}
+
+	function test_get_posts_to_update_returns_only_specified_ids() {
+		$post_id  = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$page_id  = self::factory()->post->create( [ 'post_type' => 'page', 'post_status' => 'publish' ] );
+		$extra_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		$posts = $this->agent->get_posts_to_update( [ 'only' => "$post_id,$page_id" ] );
+
+		$this->assertContains( $post_id, $posts );
+		$this->assertContains( $page_id, $posts );
+		$this->assertNotContains( $extra_id, $posts );
+	}
+
+	function test_get_posts_to_update_includes_custom_post_types_when_using_only() {
+		register_post_type( 'ctb_test_cpt', [ 'public' => true ] );
+
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$cpt_id  = self::factory()->post->create( [ 'post_type' => 'ctb_test_cpt', 'post_status' => 'publish' ] );
+
+		$posts = $this->agent->get_posts_to_update( [ 'only' => "$post_id,$cpt_id" ] );
+
+		$this->assertContains( $post_id, $posts );
+		$this->assertContains( $cpt_id, $posts, '--only should include custom post type IDs' );
+
+		unregister_post_type( 'ctb_test_cpt' );
+	}
+
+	function test_get_posts_to_update_without_only_excludes_custom_post_types_by_default() {
+		register_post_type( 'ctb_test_cpt', [ 'public' => true ] );
+
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$cpt_id  = self::factory()->post->create( [ 'post_type' => 'ctb_test_cpt', 'post_status' => 'publish' ] );
+
+		$posts = $this->agent->get_posts_to_update( [] );
+
+		$this->assertContains( $post_id, $posts );
+		$this->assertNotContains( $cpt_id, $posts, 'default query should not include custom post types' );
+
+		unregister_post_type( 'ctb_test_cpt' );
+	}
+
+
+}


### PR DESCRIPTION
Fixes #251.

## Problem

When using `--only=<ids>`, the query still applied the default `post_type => ["post", "page"]` constraint. Any IDs belonging to custom post types were silently dropped from the migration queue.

## Fix

Set `post_type = "any"` inside the `--only` branch so all explicitly supplied IDs are included regardless of their post type.

## Test

```bash
# migrate a mix of posts, pages, and custom post type IDs
wp convert-to-blocks start --only=1,2,3,100,101
# all IDs should appear in the migration queue regardless of post type
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)